### PR TITLE
Add config overrides due to DM-4410

### DIFF
--- a/bin/demo.sh
+++ b/bin/demo.sh
@@ -55,7 +55,9 @@ set -e
 setup --nolocks -v -r ./astrometry_net_data astrometry_net_data
 
 rm -rf output detected-sources.txt output_small detected-sources_small.txt
-processCcdSdss.py input --id run=4192 filter=$FILTER_SET_4192 camcol=4 field=300 --id run=6377 filter=$FILTER_SET_6377 camcol=4 field=399 --output output$SIZE_EXT
+# The following config overrides are necessary for the demo to run, until new 'truth' values are computed
+# based on the new stack default of growing footprints and running the deblender. See issue 4801
+processCcdSdss.py input --id run=4192 filter=$FILTER_SET_4192 camcol=4 field=300 --id run=6377 filter=$FILTER_SET_6377 camcol=4 field=399 --config detection.returnOriginalFootprints=True --config doDeblend=False --output output$SIZE_EXT
 
 # We need to explicitly run Python here as the command to allow 
 #   the library load path environment to be passed to export-results 


### PR DESCRIPTION
DM-4410 introduced new default parameters for growing Footprints,
and running the deblender. Command line overrides were added to
ensure the demo was run with a configuration of the stack prior to
DM-4410 until the demo comparison values can be suitably updated.
