### PR TITLE
DM-6984: Send log to stderr

### DIFF
--- a/bin/export-results
+++ b/bin/export-results
@@ -3,8 +3,17 @@ import re
 import sys
 import numpy as np
 import lsst.daf.persistence as dafPersist
+import lsst.log
 from lsst.obs.sdss import SdssMapper
 from lsst.afw.geom import Angle
+
+
+lsst.log.configure_prop("""
+log4j.rootLogger=INFO, A1
+log4j.appender.A1=ConsoleAppender
+log4j.appender.A1.Target=System.err
+log4j.appender.A1.layout=PatternLayout
+""")
 
 if len(sys.argv) != 2:
     print >>sys.stderr, "Usage: export-results <output_directory>"


### PR DESCRIPTION
The default configuration of lsst.log is at DEBUG level sent to
stdout; the default of lsst.pex.logging is at INFO level sent
to stderr.  As the stack is converted to use lsst.log instead of
lsst.pex.logging, it can add debug messages to the outputted
detected-sources file, and fail the comparison.  This commit
configures the log to be similar to the old pex_logging.