### PR TITLE
Insert explicit 'python' in calling bin routines.

### DIFF
--- a/README
+++ b/README
@@ -35,7 +35,7 @@ output; choose a result set appropriate for your system. The ./bin/compare
 script can then be used to check if your results are within the expected
 numerical tolerances::
 
-    $ bin/compare detected-sources.txt
+    $ python bin/compare detected-sources.txt
     Ok.
 
 If you use the "--small" run option then the corresponding output file is
@@ -44,7 +44,7 @@ called "output_small".
 
 Check the astrometric relative RMS with::
 
-    $ bin/check_astrometry output
+    $ python bin/check_astrometry output
 
 Included Data
 -------------


### PR DESCRIPTION
Step around the Mac SIP issues by adding to the README the instructions to

python bin/compare
python bin/check_astrometry

to explicitly use the current python while allowing the passing of environment.