### PR TITLE
Change afw field from type int to np.int32 in bin/check_astrometry 

### DIFF
--- a/bin/check_astrometry
+++ b/bin/check_astrometry
@@ -70,7 +70,7 @@ def loadAndMatchData(repo, visits, fields, ref, ref_field, camcol, filter):
             oldSchema = oldSrc.getSchema()
             mapper = afwTable.SchemaMapper(oldSchema)
             mapper.addMinimalSchema(oldSchema)
-            mapper.addOutputField(afwTable.Field[int]("camcol", "camcol number"))
+            mapper.addOutputField(afwTable.Field[np.int32]("camcol", "camcol number"))
             newSchema = mapper.getOutputSchema()
 
             # create the new extented source catalog


### PR DESCRIPTION
Following the guidance from

https://github.com/lsst/afw/pull/110

The afw field entry is modified from int to np.int32. Otherwise the test crashes.