### PR TITLE
DM-15040: Ensure that the local setup does not unset everything else

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .cache
+.pytest_cache
 pytest_session.txt
 output
 output_small

--- a/bin/demo.sh
+++ b/bin/demo.sh
@@ -52,7 +52,7 @@ test -d astrometry_net_data || { echo "Could not find the 'astrometry_net_data' 
 set -e
 
 # Tell the stack where to find astrometric reference catalogs
-setup --nolocks -v -r ./astrometry_net_data astrometry_net_data
+setup --nolocks -v -k -r ./astrometry_net_data astrometry_net_data
 
 rm -rf output detected-sources.txt output_small detected-sources_small.txt
 # The following config overrides are necessary for the demo to run, until new 'truth' values are computed


### PR DESCRIPTION
The demo script sets up a local astrometry_net_data but previously
it affected the environment more than it should. Change things
to only setup this local package without affecting others.